### PR TITLE
Prevents an uncaught exception from being thrown for content that is more than 160 characters

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -36,7 +36,6 @@ return [
                 'class'        => \MauticPlugin\MauticSlooceTransportBundle\Transport\SlooceTransport::class,
                 'arguments'    => [
                     'mautic.page.model.trackable',
-                    'mautic.helper.phone_number',
                     'mautic.integrations.helper',
                     'monolog.logger.mautic',
                     'mautic.slooce.connector',

--- a/Message/MtMessage.php
+++ b/Message/MtMessage.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticSlooceTransportBundle\Message;
 
-use MauticPlugin\MauticSlooceTransportBundle\Exception\InvalidMessageArgumentsException;
-
 /**
  * Class Message.
  *
@@ -67,14 +65,9 @@ class MtMessage extends AbstractMessage
      * @param $content
      *
      * @return MtMessage
-     *
-     * @throws InvalidMessageArgumentsException
      */
     public function setContent($content): MtMessage
     {
-        if (strlen($content) > self::MAXIMUM_LENGTH) {
-            throw new InvalidMessageArgumentsException('Message may not be longer than '.self::MAXIMUM_LENGTH.' characters');
-        }
         $this->content = $content;
 
         return $this;


### PR DESCRIPTION
If a content ended up with more than 160 characters, the InvalidMessageArgumentsException exception was thrown outside of the SlooceTransport's try/catch causing it to bubble all the way to the campaign command executing it which in turn caused us to abruptly halt processing a batch of campaign events. This removes that code because it's handled already in the try block with `MessageContentValidator::validate`.

to reproduce:

1. Create a SMS with more than 160 characters
2. Setup slooce (it doesn't have to be real credentials to test this)
3. Create a campaign to send the message
4. Run the community command `php app/console mautic:campaign:trigger -i ID` replacing ID with your campaign ID
5. Note the uncaught exception

To test:
1. Repeat with a new contact and the command should complete processing but if you look in the contact's timeline, you'll see an invalid error message. 