### PR TITLE
Encode special chars to prevent message rejection

### DIFF
--- a/Exception/InvalidRecipientException.php
+++ b/Exception/InvalidRecipientException.php
@@ -14,6 +14,6 @@ namespace MauticPlugin\MauticSlooceTransportBundle\Exception;
 /**
  * Class InvalidRecipientException.
  */
-class InvalidRecipientException extends MessageException
+class InvalidRecipientException extends SlooceServerException
 {
 }

--- a/Exception/SlooceServerException.php
+++ b/Exception/SlooceServerException.php
@@ -11,23 +11,35 @@
 
 namespace MauticPlugin\MauticSlooceTransportBundle\Exception;
 
-use MauticPlugin\MauticSlooceTransportBundle\Message\AbstractMessage;
-
 /**
  * Class SlooceServerException.
  */
-class SlooceServerException extends \Exception
+class SlooceServerException extends SloocePluginException
 {
+    /**
+     * @var null|string
+     */
+    private $payload;
+
     /**
      * SlooceServerException constructor.
      *
-     * @param string $xmlResponse
-     * @param int    $httpCode
+     * @param string      $xmlResponse
+     * @param int         $httpCode
+     * @param null|string $payload
      */
-    public function __construct(string $xmlResponse, int $httpCode)
+    public function __construct(string $xmlResponse, int $httpCode, string $payload = null)
     {
         $message = sprintf('%s (%d)', $xmlResponse, $httpCode);
 
-        parent::__construct($message, $httpCode);
+        parent::__construct($message, $httpCode, $payload);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPayload()
+    {
+        return $this->payload;
     }
 }

--- a/Message/MtMessage.php
+++ b/Message/MtMessage.php
@@ -68,6 +68,9 @@ class MtMessage extends AbstractMessage
      */
     public function setContent($content): MtMessage
     {
+        // Because this is XML based, these characters must be encoded based on Slooce docs
+        $content = htmlspecialchars($content, ENT_QUOTES|ENT_HTML5);
+
         $this->content = $content;
 
         return $this;

--- a/Tests/Message/MtMessageTest.php
+++ b/Tests/Message/MtMessageTest.php
@@ -48,4 +48,12 @@ class MtMessageTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertArrayNotHasKey(MtMessage::PASSWORD_ELEMENT, $this->message->getSanitizedArray());
     }
+
+    public function testSpecialCharactersAreEncoded()
+    {
+        $content = "<Check out> Sally & Mike's \"puppy\"";
+        $this->message->setContent($content);
+        $this->assertEquals('&lt;Check out&gt; Sally &amp; Mike&apos;s &quot;puppy&quot;', $this->message->getContent());
+
+    }
 }

--- a/Transport/SlooceTransport.php
+++ b/Transport/SlooceTransport.php
@@ -165,7 +165,11 @@ class SlooceTransport extends AbstractSmsApi
 
             return 'mautic.slooce.failed.invalid_phone_number';
         } catch (InvalidRecipientException $exception) {    // There is something with the user, probably opt-out
-            $this->logger->addInfo('Invalid recipient', ['error' => $exception->getMessage()]);
+            $this->logger->addInfo(
+                'Invalid recipient',
+                ['error' => $exception->getMessage(), 'number' => $number, 'keyword' => $message->getKeyword(), 'payload' => $exception->getPayload()]
+            );
+
             $this->unsubscribeInvalidUser($contact, $exception);
 
             return 'mautic.slooce.failed.rejected_recipient';
@@ -179,7 +183,7 @@ class SlooceTransport extends AbstractSmsApi
         } catch (SlooceServerException $exception) {
             $this->logger->addError(
                 'Server response error.',
-                ['error' => $exception->getMessage(), 'number' => $number, 'keyword' => $message->getKeyword()]
+                ['error' => $exception->getMessage(), 'number' => $number, 'keyword' => $message->getKeyword(), 'payload' => $exception->getPayload()]
             );
 
             return $exception->getMessage();


### PR DESCRIPTION
This PR logs the payload we sent to Slooce for rejections from them and also fixed issue that special characters caused the message to be rejected. 

Per Slooce API documentation:

```
Message Encoding
XML messages are exchanged in UTF-8 encoding. End-user message content submitted to Slooce
should use XML escape sequences for any characters that may otherwise conflict with XML syntax:
& &amp;
< &lt;
> &gt;
" &quot;
' &apos;
```

To reproduce: 
Send a text message with content with `Dave & Busters` and it will be rejected by Slooce as "empty mt request."

To test:
Repeat and it'll be delivered