### PR TITLE
Fix Slooce config form

### DIFF
--- a/Form/Type/ConfigAuthType.php
+++ b/Form/Type/ConfigAuthType.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticSlooceTransportBundle\Form\Type;
 
-use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\IntegrationsBundle\Form\Type\Auth\BasicAuthKeysTrait;
+use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -64,7 +64,6 @@ class ConfigAuthType extends AbstractType
                     'class' => 'form-control',
                 ],
                 'constraints' => [$this->getNotBlankConstraint()],
-                'empty_value' => '',
             ]
         );
 


### PR DESCRIPTION
https://backlog.acquia.com/browse/MAUT-3445

You can now see and save slooce plugin config form